### PR TITLE
Using consistent form_id setting

### DIFF
--- a/_includes/xlsform.md
+++ b/_includes/xlsform.md
@@ -644,11 +644,11 @@ The column headings in this example **settings** worksheet do the following:
 
 Encrypted forms provide a mechanism to keep your data private using http for communication. Form submissions sent to the Aggregate server are encrypted and completely inaccessible to anyone not possessing the private key.
 
-To encrypt XLS forms, add the **id_string**, **submission_url** and the **public_key** as column headers in the settings worksheet.
+To encrypt XLS forms, add the **form_id**, **submission_url** and the **public_key** as column headers in the settings worksheet.
 
 They do the following:
 
-  * **id_string** - name used to identify the form
+  * **form_id** - name used to identify the form
   * **submission_url** - is your submission url
   * **public_key** - is the base64RsaPublicKey
 


### PR DESCRIPTION
Rather than `id_string`

Note: `form_id` is actually an alias for the original value `id_string` but since `form_id` is mentioned repeatedly in this doc, it seems to be the preferred setting.
