### PR TITLE
Added type=file, closes #64

### DIFF
--- a/_includes/xlsform.md
+++ b/_includes/xlsform.md
@@ -100,6 +100,7 @@ XLSForm supports a number of question types. These are just some of the options 
 | image         | Take a picture.      |
 | audio         | Take an audio recording.      |
 | video         | Take a video recording.      |
+| file          | Generic file input (txt, pdf, xls, xlsx, doc, docx, rtf, zip)|
 | barcode       | Scan a barcode, requires the barcode scanner app to be installed.      |
 | calculate     | Perform a calculation; see the **Calculation** section below.|
 | acknowledge   | Acknowledge prompt that sets value to "OK" if selected.  |


### PR DESCRIPTION
pyxform includes `"text/plain,application/pdf,application/vnd.ms-excel,application/msword,text/richtext,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/zip,application/x-zip,application/x-zip-compressed"` for type=file (note that this was meant as an initial list that can be expanded when the need arises).