### PR TITLE
Improved styling and consistency of tables, closes #132

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install [Jekyll](https://jekyllrb.com/) and run with `jekyll serve --watch` on h
 
 ### Edit
 
-All content is in the `_sections` and `_data` folder. 
+All content is in the `_sections` and `_data` folders. 
 
 ### Add a translation
 

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -13,7 +13,7 @@
 {% endfor %}
 {% endcapture %}
 {% assign incl-columns = columns | replace: ' ', '' | strip_newlines | split: ',' %}
-<table>
+<table class="{{include.sheet}}-sheet">
   <thead>
     {% for prop in site.data[include.sheet].first %}
       {% if incl-columns[forloop.index0] == '1' %}

--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -18,8 +18,6 @@ This worksheet gives your form its overall structure and contains most of the co
 ### The choices worksheet
 This worksheet is used to specify the answer choices for multiple choice questions. Each row represents an answer choice. Answer choices with the same **list name** are considered part of a related set of choices and will appear together for a question. This also allows a set of choices to be reused for multiple questions (for example, yes/no questions).
 
-![](https://farm4.staticflickr.com/3767/13734054823_d2b3beb03d.jpg)
-
 Both of these worksheets have a set of mandatory columns that must be present for the form to work. Additionally, each worksheet has a set of optional columns that allow further control over the behavior of each entry in the form, but are not essential to have. Every entry must have values for each of the mandatory columns, but the optional columns may be left blank.
 
 * The **survey** worksheet has 3 mandatory columns: **type**, **name**, and **label**.
@@ -27,14 +25,27 @@ Both of these worksheets have a set of mandatory columns that must be present fo
   * The **name** column specifies the unique variable name for that entry. No two entries can have the same name.
   * The **label** column contains the actual text you see in the form. Alternatively, <a href="#language">label translation columns</a> can be used.
 
-![](https://farm4.staticflickr.com/3750/13912042263_eab8f6c1b2.jpg)
+| type                | name     | label                |
+| ------------------- | -------- | -------------------- |
+| today               | today    |                      |
+| select_one gender   | gender   | Respondent's gender? |
+| integer             | age      | Respondent's age?    |
+| =================== | ======== | ==================== |
+| choices             |          |                      |
 
 * The **choices** worksheet has 3 mandatory columns as well: **list name**, **name**, and **label**.
   * The **list name** column lets you group together a set of related answer choices, i.e., answer choices that should appear together under a question.
   * The **name** column specifies the unique variable name for that answer choice.
   * The **label** column shows the answer choice exactly as you want it to appear on the form. Alternatively, <a href="#language">label translation columns</a> can be used.
 
-![](https://farm8.staticflickr.com/7190/13888981636_de6f800cf9.jpg)
+| type                | name        | label                |
+| ------------------- | ----------- | -------------------- |
+| gender              | transgender | Transgender          |
+| gender              | female      | Female               |
+| gender              | male        | Male                 |
+| gender              | other       | Other                |
+| =================== | ========    | ==================== |
+| choices             |             |                      |
 
 The columns you add to your Excel workbook, whether they are mandatory or optional, may appear in any order. Optional columns may be left out completely. Any number of rows may be left blank. All .xls file formatting is ignored, so you can use dividing lines, shading, and other font formatting to make the form more readable.
 
@@ -72,11 +83,13 @@ XLSForm supports a number of question types. These are just some of the options 
 ### GPS
 For example, to collect the name and GPS coordinates of a store, you would write the following:
 
-| survey |          |            |                                            |
-| ------ | -------- | ---------- | ------------------------------------------ |
-|        | type     | name       | label                                      |
-|        | text     | store_name | What is the name of this store?            |
-|        | geopoint | store_gps  | Collect the GPS coordinates of this store. |
+
+| type       | name         | label                                        |
+| ---------- | ------------ | -------------------------------------------- |
+| text       | store_name   | What is the name of this store?              |
+| geopoint   | store_gps    | Collect the GPS coordinates of this store.   |
+| ========== | ============ | ============================================ |
+| survey     |              |                                              |
 
 See the [question_types XLSForm](https://docs.google.com/spreadsheets/d/1P4roHU0iC_Xx0028oKK656FvH4MBWecIw-HJ7JRwrYs/edit?usp=sharing) for a look at each question type being used in a form.
 
@@ -84,10 +97,11 @@ See the [question_types XLSForm](https://docs.google.com/spreadsheets/d/1P4roHU0
 
 When recording GPS coordinates in ODK Collect, ODK collect automatically collects the gps when an accuracy level of 5 meters or less is reached. You can change this default behaviour by specifying an **accuracyThreshold**; this could be less than 5m or more than 5m. You will need to add a column with heading **body::accuracyThreshold** on the survey sheet of your XLSForm. Then specify your preferred accuracy threshold value for this column on your geopoint question, as in the example shown below:
 
-| survey |          |           |                                            |                         |
-| ------ | -------- | --------- | ------------------------------------------ | ----------------------- |
-|        | type     | name      | label                                      | body::accuracyThreshold |
-|        | geopoint | store_gps | Collect the GPS coordinates of this store. | 1.5                     |
+| type       | name         | label                                       | body::accuracyThreshold   |
+| ---------- | ------------ | ------------------------------------------- | ------------------------- |
+| geopoint   | store_gps    | Collect the GPS coordinates of this store.  | 1.5                       |
+| ========== | ============ | =========================================== | ========================= |
+| survey     |              |                                             |                           |
 
 See [gps_accuracy_threshold](https://docs.google.com/spreadsheets/d/1kdV-UF65WONU251Zh7ngdPiQ_VrEKTNmgOHyNonSsGw/edit?usp=sharing) form for an example that uses this attribute.
 
@@ -95,43 +109,62 @@ See [gps_accuracy_threshold](https://docs.google.com/spreadsheets/d/1kdV-UF65WON
 
 XLSForm supports both **select_one** (select only one answer) and **select_multiple** (select multiple answers) questions. Writing a multiple choice question requires adding a **choices** worksheet to your Excel workbook. Here is an example of a **select_one** question:
 
-| survey      |                   |             |                    |
-| ----------- | ----------------- | ----------- | ------------------ |
-|             | type              | name        | label              |
-|             | select_one yes_no | likes_pizza | Do you like pizza? |
-| **choices** |                   |             |                    |
-|             | list name         | name        | label              |
-|             | yes_no            | yes         | Yes                |
-|             | yes_no            | no          | No                 |
 
+| type              | name          | label                     |
+| ----------------- | ------------- | ------------------------- |
+| select_one yes_no | likes_pizza   | Do you like pizza?        |
+| ============      | ============= | ========================= |
+| survey            |               |                           |
+
+<p/>
+
+| list name    | name        | label    |
+| ------------ | ----------- | -------- |
+| yes_no       | yes         | Yes      |
+| yes_no       | no          | No       |
+| ============ | =========== | ======== |
+| choices      |             |          |
 
 Note that the **yes_no** in the **survey** worksheet must match the **yes_no** in the **list name** column in the **choices** worksheet. This ensures that the form displays the correct list of answer choices for a particular question.  
 
 We can also add multiple choice questions that allow multiple answers to be selected, like so:
 
-| survey      |                                |                   |                                        |
-| ----------- | ------------------------------ | ----------------- | -------------------------------------- |
-|             | type                           | name              | label                                  |
-|             | select_multiple pizza_toppings | favorite_toppings | What are your favorite pizza toppings? |
-| **choices** |                                |                   |                                        |
-|             | list name                      | name              | label                                  |
-|             | pizza_toppings                 | cheese            | Cheese                                 |
-|             | pizza_toppings                 | pepperoni         | Pepperoni                              |
-|             | pizza_toppings                 | sausage           | Sausage                                |
+| type                           | name              | label                                       |
+| ------------------------------ | ----------------- | ------------------------------------------- |
+| select_multiple pizza_toppings | favorite_toppings | What are your favorite pizza toppings?      |
+| ===========================    | ============      | =========================================== |
+| survey                         |                   |                                             |
 
+<p/>
+
+| list name      | name          | label                     |
+| -------------- | ------------- | ------------------------- |
+| pizza_toppings | cheese        | Cheese                    |
+| pizza_toppings | pepperoni     | Pepperoni                 |
+| pizza_toppings | sausage       | Sausage                   |
+| ============   | ============= | ========================= |
+| choices        |               |                           |
 
 ### Specify other
 For multiple choice questions, surveys often include an option of marking **other** when their answer choice is not listed. Then they are usually asked to specify the other option. This is possible through XLSForm by including **or_other** after the answer choice list name in the survey worksheet. The choices worksheet stays the same. See below:
 
-| survey      |                                         |                  |                                        |
-| ----------- | --------------------------------------- | ---------------- | -------------------------------------- |
-|             | type                                    | name             | label                                  |
-|             | select_multiple pizza_toppings or_other | favorite_topping | What are your favorite pizza toppings? |
-| **choices** |                                         |                  |                                        |
-|             | list name                               | name             | label                                  |
-|             | pizza_toppings                          | cheese           | Cheese                                 |
-|             | pizza_toppings                          | pepperoni        | Pepperoni                              |
-|             | pizza_toppings                          | sausage          | Sausage                                |
+
+| type                                    | name             | label                                       |
+| --------------------------------------- | ---------------- | ------------------------------------------- |
+| select_multiple pizza_toppings or_other | favorite_topping | What are your favorite pizza toppings?      |
+| ===========================             | ============     | =========================================== |
+| survey                                  |                  |                                             |
+
+<p/>
+
+| list name      | name       | label                     |
+| -------------- | ---------- | ------------------------- |
+| list name      | name       | label                     |
+| pizza_toppings | cheese     | Cheese                    |
+| pizza_toppings | pepperoni  | Pepperoni                 |
+| pizza_toppings | sausage    | Sausage                   |
+| ============   | ========== | ========================= |
+| choices        |            |                           |
 
 Click on the link to look at the complete [pizza_questionnaire](https://docs.google.com/spreadsheets/d/1y9LcFUaJ_MDRpqbzHVxkD_k6YzSQCllqh3Excy4iffg/edit?usp=sharing).
 
@@ -141,10 +174,11 @@ When you export data using this **or_other** option, in the **favorite_topping**
 ### Range
 To restrict integer inputs to a specific range, you can use the **range** question. This question can be used with 3 optional space-separated parameters: **start**, **end**, and **step** in a **parameters** column. The default values are 0, 10, and 1 respectively. The example below will create a question that allows input from 0 until 17 with a step of 1.
 
-| survey |       |        |                               |                       |
-| ------ | ----- | ------ | ----------------------------- | --------------------- |
-|        | type  | name   | label                         | parameters            |
-|        | range | amount | What is the age of the child? | start=0 end=17 step=1 |
+| type                      | name         | label                         | parameters            |
+| ------------------------- | ------------ | ----------------------------- | --------------------- |
+| range                     | amount       | What is the age of the child? | start=0 end=17 step=1 |
+| ========================= | ============ | ============================= | ==================    |
+| survey                    |              |                               |                       |
 
 
 ### Metadata
@@ -167,18 +201,19 @@ Note that some metadata fields only apply for mobile phone-based forms.
 
 If I wanted my survey to collect all of these metadata, I would put the following at the beginning of the survey:
 
-| survey |              |              |       |
-| ------ | ------------ | ------------ | ----- |
-|        | type         | name         | label |
-|        | start        | start        |       |
-|        | end          | end          |       |
-|        | today        | today        |       |
-|        | deviceid     | deviceid     |       |
-|        | subscriberid | subscriberid |       |
-|        | simserial    | simserial    |       |
-|        | phonenumber  | phonenumber  |       |
-|        | username     | username     |       |
-|        | email        | email        |       |
+| type                      | name         | label |
+| ------------------------- | ------------ | ----- |
+| start                     | start        |       |
+| end                       | end          |       |
+| today                     | today        |       |
+| deviceid                  | deviceid     |       |
+| subscriberid              | subscriberid |       |
+| simserial                 | simserial    |       |
+| phonenumber               | phonenumber  |       |
+| username                  | username     |       |
+| email                     | email        |       |
+| ========================= | ============ | ===   |
+| survey                    |              |       |
 
 Notice that there are no labels associated with the metadata question types.  This is because the phone captures these variables automatically. These questions will not appear on the screen of the phone, but you will see them when viewing your submitted survey data.
 The [Tutorial XLSForm](https://docs.google.com/spreadsheets/d/1OPBXLH8XAVPfyOjoC4-gn2bhZ4hOm2gCtIEyszw0NRo/edit?usp=sharing) shows how metadata is used in a form.
@@ -187,22 +222,26 @@ The [Tutorial XLSForm](https://docs.google.com/spreadsheets/d/1OPBXLH8XAVPfyOjoC
 
 For advanced users, who need to perform complex queries on external data without restrictions, an external XML data file can be added with question type **xml-external**. The value in the **name** column can be used to refer to this data in any formula (e.g. for a calculation, constraint, relevant, or choice_filter) using the **instance('name')** function. A file with the same name and the **.xml** extension should be uploaded with the form. See below for an example that requires uploading a file called houses.xml with the form.
 
-| survey |              |        |                 |                                                              |
-| ------ | ------------ | ------ | --------------- | ------------------------------------------------------------ |
-|        | type         | name   | label           | calculation                                                  |
-|        | xml-external | houses |                 |                                                              |
-|        | integer      | rooms  | How many rooms? |                                                              |
-|        | calculate    | count  |                 | count(instance('houses')/house[rooms = current()/../rooms ]) |
+
+
+| type                      | name         | label           | calculation                                                  |
+| ------------------------- | ------------ | --------------- | ------------------------------------------------------------ |
+| xml-external              | houses       |                 |                                                              |
+| integer                   | rooms        | How many rooms? |                                                              |
+| calculate                 | count        |                 | count(instance('houses')/house[rooms = current()/../rooms ]) |
+| ========================= | ============ | ==========      | ============================================================ |
+| survey                    |              |                 |                                                              |
 
 ## Hints
 
 Sometimes you want to add a small hint to a question on your form, instructing the user how to answer the question, but you don't want the hint to be part of the question itself. It’s easy to add hints to questions in XLSForms.  Simply add a **hint** column and add your hint message. See below for an example.
 
-| survey |          |          |                                            |                                                     |
-| ------ | -------- | -------- | ------------------------------------------ | --------------------------------------------------- |
-|        | type     | name     | label                                      | hint                                                |
-|        | text     | name     | What is the name of this store?            | Look on the signboard if the store has a signboard. |
-|        | geopoint | geopoint | Collect the GPS coordinates of this store. |                                                     |
+| type     | name     | label                                      | hint                                                 |
+| -------- | -------- | ------------------------------------------ | ---------------------------------------------------- |
+| text     | name     | What is the name of this store?            | Look on the signboard if the store has a signboard.  |
+| geopoint | geopoint | Collect the GPS coordinates of this store. |                                                      |
+| ======== | ======== | ========================================== | ==================================================== |
+| survey   |          |                                            |                                                      |
 
 The [Tutorial XLSForm](https://docs.google.com/spreadsheets/d/1OPBXLH8XAVPfyOjoC4-gn2bhZ4hOm2gCtIEyszw0NRo/edit?usp=sharing) provides more examples of questions with hints.
 
@@ -210,10 +249,11 @@ The [Tutorial XLSForm](https://docs.google.com/spreadsheets/d/1OPBXLH8XAVPfyOjoC
 
 One way to ensure data quality is to add constraints to the data fields in your form.  For example, when asking for a person's age, you want to avoid impossible answers, like -22 or 200.  Adding data constraints in your form is easy to do.  You simply add a new column, called **constraint**, and type in the formula specifying the limits on the answer.  In the example below, the answer for the person's age must be less than or equal to 150. Note how the ``.`` in the formula refers back to the question variable.
 
-| survey |         |      |                  |            |
-| ------ | ------- | ---- | ---------------- | ---------- |
-|        | type    | name | label            | constraint |
-|        | integer | age  | How old are you? | . <= 150   |
+| type     | name     | label            | constraint |
+| -------- | -------- | ---------------- | ---------- |
+| integer  | age      | How old are you? | . <= 150   |
+| ======== | ======== | ==============   | =========  |
+| survey   |          |                  |            |
 
 In this example, the formula ```. <= 150``` is saying that the value entered ``.`` for the question must be less than or equal to 150. If the user puts 151 or above as the answer, s/he will not be allowed to move on to the next question or submit the form.
 
@@ -223,10 +263,11 @@ Other useful expressions to use in the **constraint** column can be found [here]
 
 If you want to include a message with your constraint, telling the user why the answer is not accepted, you can add a **constraint_message** column to your form.  See the example below.
 
-| survey |         |                |                  |            |                                                        |
-| ------ | ------- | -------------- | ---------------- | ---------- | ------------------------------------------------------ |
-|        | type    | name           | label            | constraint | constraint_message                                     |
-|        | integer | respondent_age | Respondent's age | . >=18     | Respondent must be 18 or older to complete the survey. |
+| type     | name           | label            | constraint | constraint_message                                     |
+| -------- | -------------- | ---------------- | ---------- | ------------------------------------------------------ |
+| integer  | respondent_age | Respondent's age | . >=18     | Respondent must be 18 or older to complete the survey. |
+| ======== | ========       | ===============  | =========  | =============================                          |
+| survey   |                |                  |            |                                                        |
 
 In this example, if the user enters an age less than 18, then the error message in the **constraint_message** column appears. More examples on constraints have been illustrated in this [XLSForm](https://docs.google.com/spreadsheets/d/1g12xGrOsnNYezG6WtTfeusxzypRT1JHeUC2uNbe03sc/edit?usp=sharing).
 
@@ -235,44 +276,56 @@ In this example, if the user enters an age less than 18, then the error message 
 One great feature of XLSForm is the ability to skip a question or make an additional question appear based on the response to a previous question. Below is an example of how to do this by adding a **relevant** column for a **select_one** question, using our pizza topping example from before:
 
 
-| survey |                                         |                  |                    |                        |
-| ------ | --------------------------------------- | ---------------- | ------------------ | ---------------------- |
-|        | type                                    | name             | label              | relevant               |
-|        | select_one yes_no                       | likes_pizza      | Do you like pizza? |                        |
-|        | select_multiple pizza_toppings or_other | favorite_topping | Favorite toppings  | ${likes_pizza} = 'yes' |
+| type                                    | name             | label              | relevant                                             |
+| --------------------------------------- | ---------------- | ------------------ | ---------------------------------------------------- |
+| select_one yes_no                       | likes_pizza      | Do you like pizza? |                                                      |
+| select_multiple pizza_toppings or_other | favorite_topping | Favorite toppings  | ${likes_pizza} = 'yes'                               |
+| ========                                | ========         | =================  | ==================================================== |
+| survey                                  |                  |                    |                                                      |
 
 In this example, the respondent is asked, “Do you like pizza?” If the answer is **yes**, then the pizza topping question appears below. Note the ``${ }`` around the variable **likes_pizza**.  These are required in order for the form to reference the variable from the previous question.  
 
 In the next example, below, we use relevant syntax for a **select_multiple** question, which is slightly different from the **select_one** question example above.
 
-| survey      |                                         |                  |                                       |                                         |
-| ----------- | --------------------------------------- | ---------------- | ------------------------------------- | --------------------------------------- |
-|             | type                                    | name             | label                                 | relevant                                |
-|             | select_one yes_no                       | likes_pizza      | Do you like pizza?                    |                                         |
-|             | select_multiple pizza_toppings or_other | favorite_topping | Favorite toppings                     | ${likes_pizza} = 'yes'                  |
-|             | text                                    | favorite_cheese  | What is your favorite type of cheese? | selected(${favorite_topping}, 'cheese') |
-| **choices** |                                         |                  |                                       |                                         |
-|             | list name                               | name             | label                                 |                                         |
-|             | pizza_toppings                          | cheese           | Cheese                                |                                         |
-|             | pizza_toppings                          | pepperoni        | Pepperoni                             |                                         |
-|             | pizza_toppings                          | sausage          | Sausage                               |                                         |
+| type                                    | name             | label                                 | relevant                                |
+| --------------------------------------- | ---------------- | ------------------------------------- | --------------------------------------- |
+| select_one yes_no                       | likes_pizza      | Do you like pizza?                    |                                         |
+| select_multiple pizza_toppings or_other | favorite_topping | Favorite toppings                     | ${likes_pizza} = 'yes'                  |
+| text                                    | favorite_cheese  | What is your favorite type of cheese? | selected(${favorite_topping}, 'cheese') |
+| ======================================= | ================ | ===================================== | ===================                     |
+| survey                                  |                  |                                       |                                         |
+
+<p/>
+
+| list name      | name         | label     |
+| -------------- | ------------ | --------- |
+| pizza_toppings | cheese       | Cheese    |
+| pizza_toppings | pepperoni    | Pepperoni |
+| pizza_toppings | sausage      | Sausage   |
+| ============== | ============ | ========= |
+| choices        |              |           |
 
 Since the pizza topping question allows multiple responses, we have to use the ``selected(${favorite_topping}, 'cheese')`` expression, because we want the cheese question to appear every time the user selects **cheese** as one of the answers (regardless of whether additional answers are selected).
 
 Earlier we mentioned there was an alternative method for specifying other for multiple choice questions which is more appropriate for large scale surveys. This can be done using the same relevant syntax from the example above:
 
+| type                           | name                    | label                                  | relevant                                |
+| ------------------------------ | ----------------------- | -------------------------------------- | --------------------------------------- |
+| select_multiple pizza_toppings | favorite_toppings       | What are your favorite pizza toppings? |                                         |
+| text                           | favorite_toppings_other | Specify other:                         | selected(${favorite_toppings}, 'other') |
+| =============================  | ==================      | =====================================  | ======================================= |
+| survey                         |                         |                                        |                                         |
 
-| survey      |                                |                         |                                        |                                         |
-| ----------- | ------------------------------ | ----------------------- | -------------------------------------- | --------------------------------------- |
-|             | type                           | name                    | label                                  | relevant                                |
-|             | select_multiple pizza_toppings | favorite_toppings       | What are your favorite pizza toppings? |                                         |
-|             | text                           | favorite_toppings_other | Specify other:                         | selected(${favorite_toppings}, 'other') |
-| **choices** |                                |                         |                                        |                                         |
-|             | list name                      | name                    | label                                  |                                         |
-|             | pizza_toppings                 | cheese                  | Cheese                                 |                                         |
-|             | pizza_toppings                 | pepperoni               | Pepperoni                              |                                         |
-|             | pizza_toppings                 | sausage                 | Sausage                                |                                         |
-|             | pizza_toppings                 | other                   | Other                                  |                                         |
+<p/>
+
+| list name           | name       | label               |
+| ------------------- | ---------- | ------------------- |
+| pizza_toppings      | cheese     | Cheese              |
+| pizza_toppings      | pepperoni  | Pepperoni           |
+| pizza_toppings      | sausage    | Sausage             |
+| pizza_toppings      | other      | Other               |
+| =================== | ========== | =================== |
+| choices             |            |                     |
 
 Note that you must include **other** as an answer choice in the **choices** worksheet.
 
@@ -285,12 +338,13 @@ Formulas are used in the constraint, relevant and calculation columns. You've al
 Your survey can perform calculations using the values of preceding questions. In most cases this will require inserting a **calculate** question. For example, in the survey below, we have calculated the tip for a meal and displayed it to the user:
 
 
-| survey |           |         |                                  |                  |
-| ------ | --------- | ------- | -------------------------------- | ---------------- |
-|        | type      | name    | label                            | calculation      |
-|        | decimal   | amount  | What was the price of the meal?  |                  |
-|        | calculate | tip     |                                  | ${amount} * 0.18 |
-|        | note      | display | 18% tip for your meal is: ${tip} |                  |
+ | type      | name     | label                                 | calculation                  |
+ | --------- | -------- | ------------------------------------- | ---------------------------- |
+ | decimal   | amount   | What was the price of the meal?       |                              |
+ | calculate | tip      |                                       | ${amount} * 0.18             |
+ | note      | display  | 18% tip for your meal is: ${tip}      |                              |
+ | ========  | ======== | ===================================== | ============================ |
+ | survey    |          |                                       |                              |
 
 Note that the **${tip}** in the last line will be replaced with the actual tip amount when viewing and filling out the form.
 
@@ -300,32 +354,36 @@ It's simple to mark certain questions as required in your form.  Marking them as
 
 To make questions required, add a **required** column to your survey worksheet. Under that column, mark questions as required by writing **yes**.  See the example below:
 
-| survey |         |      |                  |            |          |
-| ------ | ------- | ---- | ---------------- | ---------- | -------- |
-|        | type    | name | label            | constraint | required |
-|        | integer | age  | How old are you? | . <= 150   | yes      |
+ | type     | name     | label            | constraint | required   |
+ | -------- | -------- | ---------------- | ---------- | ---------- |
+ | integer  | age      | How old are you? | . <= 150   | yes        |
+ | ======== | ======== | ============     | ========== | ========== |
+ | survey   |          |                  |            |            |
 
 ### Required message
 
 If you want to customize the message displayed to users when they leave a required question blank, you can add a **required_message** column to your form.
 See the example below.
 
-| survey |         |                |                  |          |                                 |
-| ------ | ------- | -------------- | ---------------- | -------- | ------------------------------- |
-|        | type    | name           | label            | required | required_message                |
-|        | integer | respondent_age | Respondent's age | yes      | Sorry, this answer is required. |
+| type     | name           | label            | required   | required_message                |
+| -------- | -------------- | ---------------- | ---------- | ------------------------------- |
+| integer  | respondent_age | Respondent's age | yes        | Sorry, this answer is required. |
+| ======== | ========       | ============     | ========== | =============================== |
+| survey   |                |                  |            |                                 |
 
 ## Grouping questions
 
 To create a group of questions in your form try the following:
 
-| survey |             |            |                                                     |
-| ------ | ----------- | ---------- | --------------------------------------------------- |
-|        | type        | name       | label                                               |
-|        | begin group | respondent | Respondent                                          |
-|        | text        | name       | Enter the respondent’s name                        |
-|        | text        | position   | Enter the respondent’s position within the school. |
-|        | end group   |            |                                                     |
+| type        | name       | label                                               |
+| ----------- | ---------- | --------------------------------------------------- |
+| begin group | respondent | Respondent                                          |
+| text        | name       | Enter the respondent’s name                        |
+| text        | position   | Enter the respondent’s position within the school. |
+| end group   |            |                                                     |
+| ========    | ========   | ============                                        |
+| survey      |            |                                                     |
+
 
 This is a good way to group related questions for data export and analysis. Notice how **end group** doesn't require a name or label, because it is hidden in the form.
 
@@ -333,15 +391,16 @@ This is a good way to group related questions for data export and analysis. Noti
 
 Groups of questions can be nested within one another:
 
-| survey |                   |                     |                                         |
-| ------ | ----------------- | ------------------- | --------------------------------------- |
-|        | type              | name                | label                                   |
-|        | begin group       | hospital            | Hospital                                |
-|        | text              | name                | What is the name of this hospital?      |
-|        | begin group       | hiv_medication      | HIV Medication                          |
-|        | select_one yes_no | have_hiv_medication | Does this hospital have HIV medication? |
-|        | end group         |                     |                                         |
-|        | end group         |                     |                                         |
+| type              | name                | label                                   |
+| ----------------- | ------------------- | --------------------------------------- |
+| begin group       | hospital            | Hospital                                |
+| text              | name                | What is the name of this hospital?      |
+| begin group       | hiv_medication      | HIV Medication                          |
+| select_one yes_no | have_hiv_medication | Does this hospital have HIV medication? |
+| end group         |                     |                                         |
+| end group         |                     |                                         |
+| ========          | ========            | ============                            |
+| survey            |                     |                                         |
 
 You always have to end the most recent group that was created first. For instance, the first **end group** you see closes the HIV medication group, and the second one closes the beginning hospital group. When working with groups and you keep getting error messages when trying to upload your form, double-check that for each **begin group** you have one **end group**.
 
@@ -349,14 +408,15 @@ You always have to end the most recent group that was created first. For instanc
 
 One neat feature of XLSForm is the ability to skip a group of questions by combining the group feature with relevant syntax. If you want to skip a group of questions all at once, put the relevant attribute at the beginning of a group like follows:
 
-|                   |       |                                                   |             |
-| ----------------- | ----- | ------------------------------------------------- | ----------- |
-| type              | name  | label                                             | relevant    |
-| integer           | age   | How old are you?                                  |             |
-| begin group       | child | Child                                             | ${age} <= 5 |
-| integer           | muac  | Record this child’s mid-upper arm circumference. |             |
-| select_one yes_no | mrdt  | Is the child’s rapid diagnostic test positive?   |             |
-| end group         |       |                                                   |             |
+| type              | name     | label                                             | relevant     |
+| ----------------- | -------- | ------------------------------------------------- | ------------ |
+| integer           | age      | How old are you?                                  |              |
+| begin group       | child    | Child                                             | ${age} <= 5  |
+| integer           | muac     | Record this child’s mid-upper arm circumference. |              |
+| select_one yes_no | mrdt     | Is the child’s rapid diagnostic test positive?   |              |
+| end group         |          |                                                   |              |
+| ================= | ======== | ================================================= | ============ |
+| survey            |          |                                                   |              |
 
 In this example, the two child group questions (**muac** and **mrdt**) will only appear if the child's **age** from the first question is less than or equal to five.
 
@@ -364,17 +424,24 @@ In this example, the two child group questions (**muac** and **mrdt**) will only
 
 A user can repeat a group of questions by using the **begin repeat** and **end repeat** construct:
 
-| survey      |                        |              |                     |
-| ----------- | ---------------------- | ------------ | ------------------- |
-|             | type                   | name         | label               |
-|             | begin repeat           | child_repeat |                     |
-|             | text                   | name         | Child's name        |
-|             | decimal                | birthweight  | Child's birthweight |
-|             | select_one male_female | sex          | Child's sex         |
-|             | end repeat             |              |                     |
-| **choices** | list name              | name         | label               |
-|             | male_female            | male         | Male                |
-|             | male_female            | female       | Female              |
+ | type                   | name         | label               |
+ | ---------------------- | ------------ | ------------------- |
+ | begin repeat           | child_repeat |                     |
+ | text                   | name         | Child's name        |
+ | decimal                | birthweight  | Child's birthweight |
+ | select_one male_female | sex          | Child's sex         |
+ | end repeat             |              |                     |
+ | =================      | ========     | ==================  |
+ | survey                 |              |                     |
+
+<p/>
+
+| list name           | name        | label       |
+| ------------------- | ----------- | ----------- |
+| male_female         | male        | Male        |
+| male_female         | female      | Female      |
+| =================== | =========== | =========== |
+| choices             |             |             |
 
 In this example, the **name**, **birthweight**, and **sex** fields are grouped together in a repeat group, and the user can repeat this group as many times as required by selecting the option in the form to start another repeat. 
 
@@ -384,44 +451,59 @@ The [Delivery Outcome](https://docs.google.com/spreadsheets/d/1_gCJml_FzJ4qiLU-y
 
 Instead of allowing an infinite number of repeats, the user can specify an exact number of repeats by using the **repeat_count** column:
 
-| survey      |                        |              |                     |              |
-| ----------- | ---------------------- | ------------ | ------------------- | ------------ |
-|             | type                   | name         | label               | repeat_count |
-|             | begin repeat           | child_repeat |                     | 3            |
-|             | text                   | name         | Child's name        |              |
-|             | decimal                | birthweight  | Child's birthweight |              |
-|             | select_one male_female | sex          | Child's sex         |              |
-|             | end repeat             |              |                     |              |
-| **choices** | list name              | name         | label               |              |
-|             | male_female            | male         | Male                |              |
-|             | male_female            | female       | Female              |              |
+| type                   | name         | label                | repeat_count |
+| ---------------------- | ------------ | -------------------- | ------------ |
+| begin repeat           | child_repeat |                      | 3            |
+| text                   | name         | Child's name         |              |
+| decimal                | birthweight  | Child's birthweight  |              |
+| select_one male_female | sex          | Child's sex          |              |
+| end repeat             |              |                      |              |
+| =================      | ========     | ==================== | ============ |
+| survey                 |              |                      |              |
+
+<p/>
+
+| list name           | name        | label       |
+| ------------------- | ----------- | ----------- |
+| male_female         | male        | Male        |
+| male_female         | female      | Female      |
+| =================== | =========== | =========== |
+| choices             |             |             |
 
 In the above example, the repeat group is restricted to **3** repeats.  
 
 Some platforms also support dynamic repeat counts.  In the example below, the number that the user inputs for the **num_hh_members** field dictates the number of times the **hh_member** group repeats: 
 
-| survey      |                        |                |                              |                   |
-| ----------- | ---------------------- | -------------- | ---------------------------- | ----------------- |
-|             | type                   | name           | label                        | repeat_count      |
-|             | integer                | num_hh_members | Number of household members? |                   |
-|             | begin repeat           | hh_member      |                              | ${num_hh_members} |
-|             | text                   | name           | Name                         |                   |
-|             | integer                | age            | Age                          |                   |
-|             | select_one male_female | gender         | Gender                       |                   |
-|             | end repeat             |                |                              |                   |
-| **choices** | list name              | name           | label                        |                   |
-|             | male_female            | male           | Male                         |                   |
-|             | male_female            | female         | Female                       |                   |
+| type                   | name           | label                        | repeat_count      |
+| ---------------------- | -------------- | ---------------------------- | ----------------- |
+| integer                | num_hh_members | Number of household members? |                   |
+| begin repeat           | hh_member      |                              | ${num_hh_members} |
+| text                   | name           | Name                         |                   |
+| integer                | age            | Age                          |                   |
+| select_one male_female | gender         | Gender                       |                   |
+| end repeat             |                |                              |                   |
+| =================      | ========       | ====================         | ============      |
+| survey                 |                |                              |                   |
+
+<p/>
+
+| list name           | name        | label       |
+| ------------------- | ----------- | ----------- |
+| male_female         | male        | Male        |
+| male_female         | female      | Female      |
+| =================== | =========== | =========== |
+| choices             |             |             |
 
 
 ## Multiple language support
 
 It’s easy to add multiple languages to a form. You simply have to name your **label::language1 (code)**,  **label::language2 (code)**, etc., and your forms will be available in multiple languages. See the example below. Select a different form language from the pulldown menu of data collection  application (this may be located under the **Menu** key) . For the form below, English and Español will show up as the possible options.
 
-| survey |         |      |                     |                       |            |
-| ------ | ------- | ---- | ------------------- | --------------------- | ---------- |
-|        | type    | name | label::English (en) | label::Español (es)   | constraint |
-|        | integer | age  | How old are you?    | ¿Cuántos años tienes? | . <= 150   |
+| type              | name        | label::English (en) | label::Español (es)   | constraint |
+| ----------------- | ----------- | ------------------- | --------------------- | ---------- |
+| integer           | age         | How old are you?    | ¿Cuántos años tienes? | . <= 150   |
+| ================= | =========== | ============        | ============          | ========== |
+| survey            |             |                     |                       |            |
 
 Form language and user interface language may be the determined separately by the application and may not match. To facilitate matching both (in the future), it is recommended, though optional, to add a 2-character language code after the language name. The official 2-character language codes, called _subtags_ are published [here](http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) (search the page with Ctrl-F or Cmd-F).
 
@@ -435,10 +517,11 @@ You can also add a different language column for hints and media files; you simp
 
 You can include questions in your form that display images or that play video or audio files. If using the ODK mobile client for form submission, you need to put the media files that you want to include in the **/odk/forms/formname-media** folder on your phone, and then reference the exact file name in the **media** column in your form. See below for an example of how to do this.
 
-| survey |      |               |               |              |              |
-| ------ | ---- | ------------- | ------------- | ------------ | ------------ |
-|        | type | name          | label         | media::image | media::video |
-|        | note | media_example | Media example | example.jpg  | example.mp4  |
+| type              | name          | label         | media::image | media::video |
+| ----------------- | ------------- | ------------- | ------------ | ------------ |
+| note              | media_example | Media example | example.jpg  | example.mp4  |
+| ================= | ===========   | ============  | ============ | ==========   |
+| survey            |               |               |              |              |
 
 Check out the [Birds XLSForm](https://docs.google.com/spreadsheets/d/1Rxft3H3xl3M9bLFGR2XhXzt1ucyFmd0qFmOQ6FaqJw4/edit?usp=sharing) which illustrates the use of media files. You can also click on the link to see the [Birds webform ](https://enketo.ona.io/x/#Ynv3).
 
@@ -469,11 +552,12 @@ For each data field that you want to pull into your survey:
 
 See below for an example:
 
-| survey |           |            |                                     |                                                 |
-| ------ | --------- | ---------- | ----------------------------------- | ----------------------------------------------- |
-|        | type      | name       | label                               | calculation                                     |
-|        | calculate | fruit      |                                     | pulldata('fruits', 'name', 'name_key', 'mango') |
-|        | note      | note_fruit | The fruit ${fruit} pulled from csv. |                                                 |
+| type      | name       | label                               | calculation                                     |
+| --------- | ---------- | ----------------------------------- | ----------------------------------------------- |
+| calculate | fruit      |                                     | pulldata('fruits', 'name', 'name_key', 'mango') |
+| note      | note_fruit | The fruit ${fruit} pulled from csv. |                                                 |
+| ========= | ========== | =================================== | =============================================== |
+| survey    |            |                                     |                                                 |
 
 Once you have loaded .csv data into a survey field using the **pulldata()** function, you can reference that field in later relevance conditions, constraints, and labels, just as you would reference any other field that was filled in by the user. 
 
@@ -499,10 +583,11 @@ The following should be done:
 
 Below is an example of the **survey worksheet**:
 
-| survey |                   |        |                |                  |
-| ------ | ----------------- | ------ | -------------- | ---------------- |
-|        | type              | name   | label          | appearance       |
-|        | select_one fruits | fruits | Select a fruit | search('fruits') |
+| type              | name   | label          | appearance       |
+| ----------------- | ------ | -------------- | ---------------- |
+| select_one fruits | fruits | Select a fruit | search('fruits') |
+| ================= | ====== | ============== | ================ |
+| survey            |        |                |                  |
 
 There are three differences when the choice list should be pulled from one of your pre-loaded .csv files:
 
@@ -527,10 +612,11 @@ If you refer to image files in this way, you must always upload those image file
 See below an example of the choices worksheet:
 <br>
 
-| choices |           |          |       |
-| ------- | --------- | -------- | ----- |
-|         | list name | name     | label |
-|         | fruits    | name_key | name  |
+| list name         | name     | label          |
+| ----------------- | -------- | -------------- |
+| fruits            | name_key | name           |
+| ================= | ======   | ============== |
+| choices           |          |                |
 
 Click on the link to see an example of a [search-and-select sample form](https://docs.google.com/spreadsheets/d/1Y0vW0cjl1nbkZczXRmcTC71Pso8dRbouPSYWGBdvBWU/edit?usp=sharing) and  the .csv file used with form can be found [here](https://docs.google.com/spreadsheets/d/1gprb7ocTYlT_seOBFY5CuoxyodcXwWOuVxmp38OX1dE/edit?usp=sharing).
 <br>
@@ -560,53 +646,54 @@ The **itemsets.csv** file can be uploaded to any ODK-compatible server (e.g., OD
 
 Adding a default field means that a question will be pre-populated with an answer when the user first sees the question.  This can help save time if the answer is one that is commonly selected or it can serve to show the user what type of answer choice is expected.  See the two examples below.
 
-| survey |       |             |              |            |
-| ------ | ----- | ----------- | ------------ | ---------- |
-|        | type  | name        | label        | default    |
-|        | today | today       |              |            |
-|        | date  | survey_date | Survey date? | 2010-06-15 |
+| type              | name        | label          | default          |
+| ----------------- | ----------- | -------------- | ---------------- |
+| today             | today       |                |                  |
+| date              | survey_date | Survey date?   | 2010-06-15       |
+| ================= | ======      | ============== | ================ |
+| survey            |             |                |                  |
 
 In the next example, the weight is automatically set to 51.3 kg.  You can simply change the answer by tapping in the answer field and inputting another answer.
 
-| survey |         |        |                               |         |
-| ------ | ------- | ------ | ----------------------------- | ------- |
-|        | type    | name   | label                         | default |
-|        | decimal | weight | Respondent's weight? (in kgs) | 51.3    |
-
+| type              | name   | label                         | default          |
+| ----------------- | ------ | ----------------------------- | ---------------- |
+| decimal           | weight | Respondent's weight? (in kgs) | 51.3             |
+| ================= | ====== | ==============                | ================ |
+| survey            |        |                               |                  |
 
 ## Read only
 
 Adding a read only field means that a question can not be edited. Read only fields can be combined with default fields to deliver information back to a user. 
 
-| survey |         |      |                    |           |         |
-| ------ | ------- | ---- | ------------------ | --------- | ------- |
-|        | type    | name | label              | read_only | default |
-|        | integer | num  | Please patient is: | yes       | 5       |
-
+| type      | name   | label              | read_only        | default |
+| --------- | ------ | ------------------ | ---------------- | ------- |
+| integer   | num    | Please patient is: | yes              | 5       |
+| ========= | ====== | ==============     | ================ |         |
+| survey    |        |                    |                  |         |
 
 ## Appearance
 
 The **appearance** column allows you to change the appearance of questions in your form. The following table lists the possible appearance attributes and how the question appears in the form.
 
-| Appearance attribute | Question type                                     | Description                                                                                                                                                                                                                     |
-| -------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| multiline            | text                                              | Best if used with web clients, makes the text box multiple lines long.                                                                                                                                                          |
-| minimal              | select_one, select_multiple                       | Answer choices appear in a pull-down menu.                                                                                                                                                                                      |
-| quick                | select_one                                        | Relevant for mobile clients only, this attribute auto-advances the form to the next question after an answer is selected.                                                                                                       |
-| no-calendar          | date                                              | For mobile devices only, used to suppress the calendar.                                                                                                                                                                         |
-| month-year           | date                                              | Select a month and year only for the date.                                                                                                                                                                                      |
-| year                 | date                                              | Select only a year for the date.                                                                                                                                                                                                |
-| horizontal-compact   | select_one, select_multiple                       | For web clients only, this displays the answer choices horizontally.                                                                                                                                                            |
-| horizontal           | select_one, select_multiple                       | For web clients only, this displays the answer choices horizontally, but in columns.                                                                                                                                            |
-| likert               | select_one                                        | Best if used with web clients, makes the answer choices appear as a Likert scale.                                                                                                                                               |
-| compact              | select_one, select_multiple | Displays answer choices side by side with minimal padding and without radio buttons or checkboxes. Particularly useful with image choices.                                                                                                                                 |
-| quickcompact         | select_one                  | Same as previous, but auto-advances to the next question (in mobile clients only).                                                                                                                                     |
-| field-list           | groups                                            | Entire group of questions appear on one screen (for mobile clients only).                                                                                                                                                       |
-| label                | select_one, select_multiple                       | Displays answer choice labels (and not inputs).                                                                                                                                                                                 |
-| list-nolabel         | select_one, select_multiple                       | Used in conjunction with **label** attribute above, displays the answer inputs without the labels (make sure to put **label** and **list-nolabel** fields inside a group with **field-list** attribute if using mobile client). |
-| table-list           | groups                                            | An easier way to achieve the same appearance as above, apply this attribute to the entire group of questions (might slow down the form a bit).                                                                                  |
-| signature            | image                                             | Allows you to trace your signature into your form (mobile clients only).                                                                                                                                                        |
-| draw                 | image                                             | Allows you to sketch a drawing with your finger on the mobile device screen.                                                                                                                                                    |
+| Appearance attribute | Question type               | Description                                                                                                                                                                                                                     |
+| -------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| multiline            | text                        | Best if used with web clients, makes the text box multiple lines long.                                                                                                                                                          |
+| minimal              | select_one, select_multiple | Answer choices appear in a pull-down menu.                                                                                                                                                                                      |
+| quick                | select_one                  | Relevant for mobile clients only, this attribute auto-advances the form to the next question after an answer is selected.                                                                                                       |
+| no-calendar          | date                        | For mobile devices only, used to suppress the calendar.                                                                                                                                                                         |
+| month-year           | date                        | Select a month and year only for the date.                                                                                                                                                                                      |
+| year                 | date                        | Select only a year for the date.                                                                                                                                                                                                |
+| horizontal-compact   | select_one, select_multiple | For web clients only, this displays the answer choices horizontally.                                                                                                                                                            |
+| horizontal           | select_one, select_multiple | For web clients only, this displays the answer choices horizontally, but in columns.                                                                                                                                            |
+| likert               | select_one                  | Best if used with web clients, makes the answer choices appear as a Likert scale.                                                                                                                                               |
+| compact              | select_one, select_multiple | Displays answer choices side by side with minimal padding and without radio buttons or checkboxes. Particularly useful with image choices.                                                                                      |
+| quickcompact         | select_one                  | Same as previous, but auto-advances to the next question (in mobile clients only).                                                                                                                                              |
+| field-list           | groups                      | Entire group of questions appear on one screen (for mobile clients only).                                                                                                                                                       |
+| label                | select_one, select_multiple | Displays answer choice labels (and not inputs).                                                                                                                                                                                 |
+| list-nolabel         | select_one, select_multiple | Used in conjunction with **label** attribute above, displays the answer inputs without the labels (make sure to put **label** and **list-nolabel** fields inside a group with **field-list** attribute if using mobile client). |
+| table-list           | groups                      | An easier way to achieve the same appearance as above, apply this attribute to the entire group of questions (might slow down the form a bit).                                                                                  |
+| signature            | image                       | Allows you to trace your signature into your form (mobile clients only).                                                                                                                                                        |
+| draw                 | image                       | Allows you to sketch a drawing with your finger on the mobile device screen.                                                                                                                                                    |
 
 An XLSForm with all of the appearance attributes in this table is available [here](https://docs.google.com/spreadsheets/d/159tf1wNeKGRccgizZBlU3arrOM--OpxWo26UvZcDEMU/edit?usp=sharing).
 
@@ -616,10 +703,11 @@ The **settings** worksheet is optional, but it allows you to further customize y
 
 An example **settings** worksheet is below:
 
-| settings |               |            |              |                                                      |                  |            |
-| -------- | ------------- | ---------- | ------------ | ---------------------------------------------------- | ---------------- | ---------- |
-|          | form_title    | form_id    | public_key   | submission_url                                       | default_language | version    |
-|          | Example Title | example_id | IIBIjANBg... | https://example-odk-aggregate.appspot.com/submission | English          | 2017021501 |
+| form_title | form_id | public_key     | submission_url                                       | default_language  | version      |
+| ---------- | ------- | -------------- | ---------------------------------------------------- | ----------------- | ------------ |
+| Example    | ex_id   | IIBIjANBg...   | https://example-odk-aggregate.appspot.com/submission | English           | 2017021501   |
+| ========   | ======  | ============== | ================                                     | ================= | ============ |
+| settings   |         |                |                                                      |                   |              |
 
 The column headings in this example **settings** worksheet do the following:
 
@@ -659,21 +747,25 @@ An example of a form divided into multiple pages can be seen on the [Widgets on 
 
 In the **settings** tab, create a column called **style** and set it to **pages**, as follows:
 
-| settings |               |            |       |
-| -------- | ------------- | ---------- | ----- |
-|          | form_title    | form_id    | style |
-|          | example title | example_id | pages |
+| form_title    | form_id    | style  |
+| ------------- | ---------- | ------ |
+| example title | example_id | pages  |
+| =========     | ========   | ====== |
+| settings      |            |        |
+
 
 In your **survey** tab, group together the questions you would like to appear on each page and then set the appearance for the group to **field-list**. See the example below.
 
-| survey |             |         |                      |            |
-| ------ | ----------- | ------- | -------------------- | ---------- |
-|        | type        | name    | label                | appearance |
-|        | begin group | group1  |                      | field-list |
-|        | text        | name    | Respondent's name    |            |
-|        | integer     | age     | Respondent's age     |            |
-|        | string      | address | Respondent's address |            |
-|        | end group   |         |                      |            |
+| type        | name     | label                | appearance |
+| ----------- | -------- | -------------------- | ---------- |
+| type        | name     | label                | appearance |
+| begin group | group1   |                      | field-list |
+| text        | name     | Respondent's name    |            |
+| integer     | age      | Respondent's age     |            |
+| string      | address  | Respondent's address |            |
+| end group   |          |                      |            |
+| =========   | ======== | ======               | ====       |
+| survey      |          |                      |            |
 
 See this [blog post](http://blog.enketo.org/pages/) for more information on creating multi-page web forms.  The XLSForm source is [here](https://docs.google.com/spreadsheets/d/1yZqG2Xt0I4duVxPqx-Sny0t86OiKtjHuBKXTRzCht6E/edit?usp=sharing.).
 
@@ -685,21 +777,23 @@ Please click on the link to see an example of a [Grid theme webform](https://enk
 
 To create a Grid form, in the **settings** tab, under the **style** column, write **theme-grid**, as follows:
 
-| settings |               |            |            |
-| -------- | ------------- | ---------- | ---------- |
-|          | form_title    | form_id    | style      |
-|          | example title | example_id | theme-grid |
+| form_title    | form_id    | style      |
+| ------------- | ---------- | ---------- |
+| example title | example_id | theme-grid |
+| =========     | ========   | ======     |
+| settings      |            |            |
 
 In your **survey** tab, group together the questions you would like to appear in each section and then set the appearance for each field according to the desired width (the default width is 4). See the example below.
 
-| survey |             |         |                      |            |
-| ------ | ----------- | ------- | -------------------- | ---------- |
-|        | type        | name    | label                | appearance |
-|        | begin group | group1  |                      |            |
-|        | text        | name    | Respondent's name    | w3         |
-|        | integer     | age     | Respondent's age     | w1         |
-|        | string      | address | Respondent's address | w4         |
-|        | end group   |         |                      |            |
+| type        | name     | label                | appearance |
+| ----------- | -------- | -------------------- | ---------- |
+| begin group | group1   |                      |            |
+| text        | name     | Respondent's name    | w3         |
+| integer     | age      | Respondent's age     | w1         |
+| string      | address  | Respondent's address | w4         |
+| end group   |          |                      |            |
+| =========   | ======== | ======               | ====       |
+| survey      |          |                      |            |
 
 See this [blog post](http://blog.enketo.org/gorgeous-grid/) for more information on creating Grid forms. The Grid theme XLSForm example is [here](https://docs.google.com/spreadsheets/d/1Z4gHZQTr5FibRK-Aj198WlNdMZghEBZlyWhmPZXjzJQ/edit?usp=sharing).  
 

--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -31,14 +31,14 @@ Both of these worksheets have a set of mandatory columns that must be present fo
 | select_one gender   | gender   | Respondent's gender? |
 | integer             | age      | Respondent's age?    |
 | =================== | ======== | ==================== |
-| choices             |          |                      |
+| survey              |          |                      |
 
 * The **choices** worksheet has 3 mandatory columns as well: **list name**, **name**, and **label**.
   * The **list name** column lets you group together a set of related answer choices, i.e., answer choices that should appear together under a question.
   * The **name** column specifies the unique variable name for that answer choice.
   * The **label** column shows the answer choice exactly as you want it to appear on the form. Alternatively, <a href="#language">label translation columns</a> can be used.
 
-| type                | name        | label                |
+| list_name           | name        | label                |
 | ------------------- | ----------- | -------------------- |
 | gender              | transgender | Transgender          |
 | gender              | female      | Female               |

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -50,8 +50,9 @@ table tfoot td:first-of-type{
   border-bottom-left-radius: 8px;
   border-bottom-right-radius: 8px;
   color: white;
-  background: #9e9e9e;
+  background:#b9b9b9;
   min-width: 150px;
+  text-align: center;
 }
 
 table tr td {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -352,6 +352,16 @@ table tr td {
 
 .post pre.terminal code { background-color: #333; }
 
+/* center ODK and Enketo columns in ref-table */
+.survey-sheet td:nth-of-type(4),
+.survey-sheet td:nth-of-type(5),
+.choices-sheet td:nth-of-type(3),
+.choices-sheet td:nth-of-type(4),
+.settings-sheet td:nth-of-type(4),
+.settings-sheet td:nth-of-type(5){
+  text-align: center;
+}
+
 /* Syntax highlighting styles */
 /* ----------------------------------------------------------*/
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -42,17 +42,55 @@ table tr th, table tr td{
 }
 
 table tfoot td {
-  border-color: transparent;
+  border: none;
+  
 }
 
-/* mimic the sheet tab */
-table tfoot td:first-of-type{
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  color: white;
-  background:#b9b9b9;
-  min-width: 150px;
+table tfoot tr {
+  border: 1px solid  #AFAFAF;
+  background: #EFEFEF;
+}
+
+tfoot td.sheets {
+  min-width: 285px;
+}
+
+/* mimic the Excel sheet navigation */
+tfoot td.sheets span{
+  display: inline-block;
+  width: 65px;
   text-align: center;
+  border-right: 1px solid #b9b9b9;
+}
+
+tfoot td.sheets span:first-of-type{
+  border-left: 1px solid #b9b9b9;
+}
+
+tfoot td.sheets::before{
+  content: "◄  ►";
+  margin: 0 10px 0 5px;
+  color: #ccc;
+}
+
+tfoot td.sheets::after{
+  content: "+";
+  display: inline-block;
+  margin-left: 15px;
+  width: 16px;
+  height: 16px;
+  line-height: 14px;
+  border-radius: 8px;
+  text-align: center;
+  vertical-align: middle;
+  border: 1px solid #AFAFAF;
+}
+
+tfoot td.sheets span.active{
+  font-weight: bold;
+  color: black;
+  border-bottom: 2px solid gray;
+  background: white;
 }
 
 table tr td {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -75,15 +75,17 @@ tfoot td.sheets::before{
 
 tfoot td.sheets::after{
   content: "+";
+  font-weight: bold;
+  color: #AFAFAF;
   display: inline-block;
   margin-left: 15px;
-  width: 16px;
-  height: 16px;
-  line-height: 14px;
-  border-radius: 8px;
+  width: 14px;
+  height: 14px;
+  line-height: 13px;
+  border-radius: 9px;
   text-align: center;
   vertical-align: middle;
-  border: 1px solid #AFAFAF;
+  border: 2px solid #ccc;
 }
 
 tfoot td.sheets span.active{

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,14 +34,36 @@ table{
 }
 table tr th{
     background:#EFEFEF;
+    font-size: 15px;
 }
 table tr th, table tr td{
     border:1px solid #AFAFAF;
     padding:0.6em;
 }
+
+table tfoot td {
+  border-color: transparent;
+}
+
+/* mimic the sheet tab */
+table tfoot td:first-of-type{
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  color: white;
+  background: #9e9e9e;
+  min-width: 150px;
+}
+
+table tr td {
+  font-size: 14px;
+}
+
 .fullpage table tr th, table tr td{
-    padding:0.1em 0.5em;
-    font-size: 11px;
+  padding:0.1em 0.5em;
+}
+
+.fullpage table tr th, .fullpage table tr td {
+  font-size: 11px;
 }
 .cleafix:before, .clearfix:after{
     content:""; display:table;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,5 +1,6 @@
 addNavMenu();
 setHeaderListeners();
+addSheets();
 shuffle(Array.prototype.slice.call(document.querySelectorAll('#platformstools-that-support-xlsforms + ul > li')))
     .forEach(function (el, index) {
         el.style.order = index;
@@ -128,4 +129,30 @@ function shuffle(array) {
     }
 
     return array;
+}
+
+function addSheets(){
+    var tfoots = document.querySelectorAll('tfoot');
+
+    for (var i=0; i< tfoots.length; i++){
+        var tds = tfoots[i].querySelectorAll('td');
+        sheet = tds[0].textContent;
+
+        tds[0].classList.add('sheets');
+        tds[0].textContent = '';
+        tds[0].setAttribute('colspan', '3');
+        
+        for (var j=0 ; j < 3 ; j++){
+            var span = document.createElement('span');
+            var type = ['survey', 'choices', 'settings'][j];
+            if (j > 0) {
+                tds[j].remove();
+            }
+            span.appendChild(document.createTextNode(type));
+            if (sheet === type){
+                span.classList.add('active');
+            }
+            tds[0].appendChild(span);
+        }
+    }
 }


### PR DESCRIPTION
Showing a sheet tab at the bottom of each table, increased font size, replaced Excel screenshots

Table styling should be tweaked further by a real designer, but with this commit we have the HTML syntax to do so.

I thought the markdown syntax for sheets (at the bottom line of a table) would be intuitive like this.