### PR TITLE
Update supported platforms

### DIFF
--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -878,7 +878,7 @@ The **settings** sheet has support for defining (multiple space-separated) addit
 | ========= | ============ | ======================== | ====================== | ============= |
 | survey    |              |                          |                        |               |
 
-## Platforms/Tools that support XLSForms
+## Tools that support XLSForms
 * [Secure Data Kit (SDK)](http://www.securedatakit.com)
 * [Open Data Kit (ODK)](http://opendatakit.org)
 * [Formhub](http://formhub.org)

--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -879,14 +879,14 @@ The **settings** sheet has support for defining (multiple space-separated) addit
 | survey    |              |                          |                        |               |
 
 ## Tools that support XLSForms
-* [Secure Data Kit (SDK)](http://www.securedatakit.com)
-* [Open Data Kit (ODK)](http://opendatakit.org)
 * [Ona](http://ona.io)
-* [SurveyCTO](http://www.surveycto.com/)
 * [Enketo](http://enketo.org)
+* [Open Data Kit (ODK)](http://opendatakit.org)
 * [Kobo ToolBox](http://kobotoolbox.org)
 * [CommCare](http://commcarehq.org)
+* [SurveyCTO](http://www.surveycto.com/)
 * [DataWinners](https://www.datawinners.com/en/home/)
+* [Secure Data Kit (SDK)](http://www.securedatakit.com)
 * [Tattara](http://tattara.com/)
 
 ## More resources

--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -881,14 +881,11 @@ The **settings** sheet has support for defining (multiple space-separated) addit
 ## Tools that support XLSForms
 * [Secure Data Kit (SDK)](http://www.securedatakit.com)
 * [Open Data Kit (ODK)](http://opendatakit.org)
-* [Formhub](http://formhub.org)
 * [Ona](http://ona.io)
 * [SurveyCTO](http://www.surveycto.com/)
 * [Enketo](http://enketo.org)
 * [Kobo ToolBox](http://kobotoolbox.org)
 * [CommCare](http://commcarehq.org)
-* Nafundi's [XLSForm Offline](https://gumroad.com/l/xlsform-offline)
-* Nathan Breit's [xlsform.exe](https://github.com/UW-ICTD/xlsform.exe/blob/master/README.md)
 * [DataWinners](https://www.datawinners.com/en/home/)
 * [Tattara](http://tattara.com/)
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,7 +1,7 @@
 addNavMenu();
 setHeaderListeners();
 addSheets();
-shuffle(Array.prototype.slice.call(document.querySelectorAll('#platformstools-that-support-xlsforms + ul > li')))
+shuffle(Array.prototype.slice.call(document.querySelectorAll('#tools-that-support-xlsforms + ul > li')))
     .forEach(function (el, index) {
         el.style.order = index;
     });


### PR DESCRIPTION
I noticed that the links to "Platforms/Tools" weren't working so I figured I'd take a crack at fixing it. This PR also:
* Dropped Formhub, XLSForm Offline, and xlsform.exe since they are no longer things
* Re-jiggered the list to sort roughly by contributions and size. Very open to changing this!