### PR TITLE
Removing sticky attribute from TOC, fixes #149

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -139,7 +139,6 @@ table tr td {
 
 @media only screen and (min-width: 900px) {
   .sidenav {
-    position: sticky;
     top: 20px;
   }
 }


### PR DESCRIPTION
This reverses the CSS solution in #103 in order to fit the entire TOC on one screen.