### PR TITLE
Correct links to multiple choice questions

### DIFF
--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -106,7 +106,7 @@ When recording GPS coordinates in ODK Collect, ODK collect automatically collect
 
 See [gps_accuracy_threshold](https://docs.google.com/spreadsheets/d/1kdV-UF65WONU251Zh7ngdPiQ_VrEKTNmgOHyNonSsGw/edit?usp=sharing) form for an example that uses this attribute.
 
-### Multiple choice questions
+### Multiple choice
 
 XLSForm supports both **select_one** (select only one answer) and **select_multiple** (select multiple answers) questions. Writing a multiple choice question requires adding a **choices** worksheet to your Excel workbook. Here is an example of a **select_one** question:
 


### PR DESCRIPTION
The markdown links to the "Multiple choice questions" section wasn't working and looks like it was just out of date.