### PR TITLE
Add section on representing zero repeats and add subheadings to repeat section

### DIFF
--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -531,6 +531,8 @@ The **label** column is optional for **begin repeat**.  Assigning a label to a r
 
 The [Delivery Outcome](https://docs.google.com/spreadsheets/d/1_gCJml_FzJ4qiLU-yc67x1iu_GL-hfU3H8-HvINsIoE/edit?usp=sharing) XLSForm is another repeat example.
 
+### Fixed repeat counts
+
 Instead of allowing an infinite number of repeats, the form designer can specify an exact number of repeats by using the **repeat_count** column:
 
 | type                   | name         | label                | repeat_count |
@@ -554,6 +556,8 @@ Instead of allowing an infinite number of repeats, the form designer can specify
 
 In the above example, exactly **3** child repeats will be created.
 
+### Dynamic repeat counts
+
 Some platforms also support dynamic repeat counts.  In the example below, the number that the user inputs for the **num_hh_members** field dictates the number of **hh_member** repeats added:
 
 | type                   | name           | label                        | repeat_count      |
@@ -576,6 +580,35 @@ Some platforms also support dynamic repeat counts.  In the example below, the nu
 | =================== | =========== | =========== |
 | choices             |             |             |
 
+### Only add repeats in certain conditions
+
+Like [with groups](#skipping), all of the questions in a repeat can be skipped based on some condition. In the example below, the person filling out the form will only be given the opportunity to add children if they first indicate that there are children to add:
+
+ | type                   | name         | label                      | relevant            |
+ | ---------------------- | ------------ | ---------------------------|---------------------|
+ | select_one yes_no      | has_child    | Do any children live here? |                     |
+ | begin repeat           | child_repeat |                            | ${has_child} = 'yes'|
+ | text                   | name         | Child's name               |                     |
+ | decimal                | birthweight  | Child's birthweight        |                     |
+ | end repeat             |              |                            |                     |
+ | =================      | ========     | ========================== | =================== |
+ | survey                 |              |                            |                     |
+
+<p/>
+
+ | list_name    | name        | label    |
+ | ------------ | ----------- | -------- |
+ | yes_no       | yes         | Yes      |
+ | yes_no       | no          | No       |
+ | ============ | =========== | ======== |
+ | choices      |             |          |
+
+### Representing zero repeats
+
+By default, the person filling the form will see the questions corresponding to one repeat before getting the option to add more. To represent 0 repeats, there are three options:
+- teach the people filling out the form to delete the first repeat added
+- if the exact number of repeats is known ahead of time, [use a dynamic repeat count](#dynamic-repeat-counts)
+- if the exact number of repeats is not known ahead of time, [use `relevant`](#only-add-repeats-in-certain-conditions) to only prompt the user for repeats if there are some to add
 
 ## Multiple language support
 

--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -529,7 +529,7 @@ In this example, the **name**, **birthweight**, and **sex** fields are grouped t
 
 The **label** column is optional for **begin repeat**.  Assigning a label to a repeat will add the label as a title to the block of repeat questions in the form.
 
-Some platforms show collapsed repeats in a table of contents. The label used to represent each repeat is the label of the first group inside that repeat. In the example below, if a repeat is filled out with values `Preity` for `first_name`, `Zinta` for `last_name` and `71` for `age`, that repeat will be summarized as "Preity Zinta - 71":
+When a repeat is shown in a table of contents, the label used to represent each repeat is the label of the first group inside that repeat. In the example below, if a repeat is filled out with values `Preity` for `first_name`, `Zinta` for `last_name` and `71` for `age`, that repeat will be summarized as "Preity Zinta - 71":
 
 | type                   | name         | label                                                   |
 | ---------------------- | ------------ | ------------------------------------------------------- |
@@ -562,7 +562,7 @@ In the above example, exactly **3** child repeats will be created.
 
 ### Dynamic repeat counts
 
-Some platforms also support dynamic repeat counts.  In the example below, the number that the user inputs for the **num_hh_members** field dictates the number of **hh_member** repeats added:
+The repeat count can be set to an expression that refers to other fields in the form. In the example below, the number that the user inputs for the **num_hh_members** field dictates the number of **hh_member** repeats added:
 
 | type                   | name           | label                        | repeat_count      |
 | ---------------------- | -------------- | ---------------------------- | ----------------- |

--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -540,19 +540,9 @@ Instead of allowing an infinite number of repeats, the form designer can specify
 | begin repeat           | child_repeat |                      | 3            |
 | text                   | name         | Child's name         |              |
 | decimal                | birthweight  | Child's birthweight  |              |
-| select_one male_female | sex          | Child's sex          |              |
 | end repeat             |              |                      |              |
 | =================      | ========     | ==================== | ============ |
 | survey                 |              |                      |              |
-
-<p/>
-
-| list name           | name        | label       |
-| ------------------- | ----------- | ----------- |
-| male_female         | male        | Male        |
-| male_female         | female      | Female      |
-| =================== | =========== | =========== |
-| choices             |             |             |
 
 In the above example, exactly **3** child repeats will be created.
 
@@ -566,19 +556,9 @@ Some platforms also support dynamic repeat counts.  In the example below, the nu
 | begin repeat           | hh_member      |                              | ${num_hh_members} |
 | text                   | name           | Name                         |                   |
 | integer                | age            | Age                          |                   |
-| select_one male_female | gender         | Gender                       |                   |
 | end repeat             |                |                              |                   |
 | =================      | ========       | ====================         | ============      |
 | survey                 |                |                              |                   |
-
-<p/>
-
-| list name           | name        | label       |
-| ------------------- | ----------- | ----------- |
-| male_female         | male        | Male        |
-| male_female         | female      | Female      |
-| =================== | =========== | =========== |
-| choices             |             |             |
 
 ### Only add repeats in certain conditions
 

--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -502,7 +502,7 @@ One neat feature of XLSForm is the ability to skip a group of questions by combi
 
 In this example, the two child group questions (**muac** and **mrdt**) will only appear if the child's **age** from the first question is less than or equal to five.
 
-### Repeats
+## Repeats
 
 A user can repeat a group of questions by using the **begin repeat** and **end repeat** construct:
 

--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -529,6 +529,20 @@ In this example, the **name**, **birthweight**, and **sex** fields are grouped t
 
 The **label** column is optional for **begin repeat**.  Assigning a label to a repeat will add the label as a title to the block of repeat questions in the form.
 
+Some platforms show collapsed repeats in a table of contents. The label used to represent each repeat is the label of the first group inside that repeat. In the example below, if a repeat is filled out with values `Preity` for `first_name`, `Zinta` for `last_name` and `71` for `age`, that repeat will be summarized as "Preity Zinta - 71":
+
+| type                   | name         | label                                                   |
+| ---------------------- | ------------ | ------------------------------------------------------- |
+| begin repeat           | person_repeat|                                                         |
+| begin group            | person       | ${first_name} ${last_name} - ${age}                     |
+| text                   | first_name   | First name                                              |
+| text                   | last_name    | Last name                                               |
+| integer                | age          | Age                                                     |
+| end group              |              |                                                         |
+| end repeat             |              |                                                         |
+| =================      | ========     | ======================================================= |
+| survey
+
 The [Delivery Outcome](https://docs.google.com/spreadsheets/d/1_gCJml_FzJ4qiLU-yc67x1iu_GL-hfU3H8-HvINsIoE/edit?usp=sharing) XLSForm is another repeat example.
 
 ### Fixed repeat counts

--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -504,7 +504,7 @@ In this example, the two child group questions (**muac** and **mrdt**) will only
 
 ## Repeats
 
-A user can repeat a group of questions by using the **begin repeat** and **end repeat** construct:
+A user can repeat questions by using the **begin repeat** and **end repeat** construct:
 
  | type                   | name         | label               |
  | ---------------------- | ------------ | ------------------- |
@@ -525,13 +525,13 @@ A user can repeat a group of questions by using the **begin repeat** and **end r
 | =================== | =========== | =========== |
 | choices             |             |             |
 
-In this example, the **name**, **birthweight**, and **sex** fields are grouped together in a repeat group, and the user can repeat this group as many times as required by selecting the option in the form to start another repeat. 
+In this example, the **name**, **birthweight**, and **sex** fields are grouped together in a repeat, and the user can collect the same information about multiple children by selecting the option in the form to add another repeat.
 
-The **label** column is optional for **begin repeat**.  Assigning a label to a repeat group will add the label as a title to the block of repeat questions in the form.
+The **label** column is optional for **begin repeat**.  Assigning a label to a repeat will add the label as a title to the block of repeat questions in the form.
 
-The [Delivery Outcome](https://docs.google.com/spreadsheets/d/1_gCJml_FzJ4qiLU-yc67x1iu_GL-hfU3H8-HvINsIoE/edit?usp=sharing) XLSForm illustrates another repeat group example.
+The [Delivery Outcome](https://docs.google.com/spreadsheets/d/1_gCJml_FzJ4qiLU-yc67x1iu_GL-hfU3H8-HvINsIoE/edit?usp=sharing) XLSForm is another repeat example.
 
-Instead of allowing an infinite number of repeats, the user can specify an exact number of repeats by using the **repeat_count** column:
+Instead of allowing an infinite number of repeats, the form designer can specify an exact number of repeats by using the **repeat_count** column:
 
 | type                   | name         | label                | repeat_count |
 | ---------------------- | ------------ | -------------------- | ------------ |
@@ -552,9 +552,9 @@ Instead of allowing an infinite number of repeats, the user can specify an exact
 | =================== | =========== | =========== |
 | choices             |             |             |
 
-In the above example, the repeat group is restricted to **3** repeats.  
+In the above example, exactly **3** child repeats will be created.
 
-Some platforms also support dynamic repeat counts.  In the example below, the number that the user inputs for the **num_hh_members** field dictates the number of times the **hh_member** group repeats: 
+Some platforms also support dynamic repeat counts.  In the example below, the number that the user inputs for the **num_hh_members** field dictates the number of **hh_member** repeats added:
 
 | type                   | name           | label                        | repeat_count      |
 | ---------------------- | -------------- | ---------------------------- | ----------------- |


### PR DESCRIPTION
In preparation for https://github.com/XLSForm/pyxform/pull/380 which will make it so that all repeats have a first instance. 

Since this results in a change in behavior for some clients, I was at first going to talk about versions and specific clients but it got too messy:
- The XLSForm spec isn't versioned (maybe it should be? Except that there isn't really a spec, just a tutorial. It's dynamic so hard to know how we'd do versioning exactly.)
- Users generally don't even know they're using pyxform so calling out that version isn't helpful
- There are a ton of systems that use pyxform as a library so it's not reasonable to try to enumerate those versions

I think it's ok to not talk about versions and to merge this before the pyxform change is released because:
- The suggestions in the new zero repeats section are helpful and good form design even with currently-released versions of pyxform that result in Collect prompting before the first repeat
- The only known client that will change in behavior is Collect because Enketo already injects the first instance
- The change in behavior will only affect newly-converted forms
- We've decided that pyxform will generate a warning for forms that include repeats and link to this documentation so that will be the natural way for users to find this information

I included a few other perhaps controversial changes. 
1. I pulled the `repeat` section to be a sibling of `groups` rather than a child. I don't think it's helpful for end users to think about `repeat groups` rather than just `repeats`. I think repeats are important enough that they merit their own section
1. I took out selects from some of the sample forms because I thought they just made the section harder to skim.
1. While I'm here, I documented how to name repeat instances. See the line before [this one](https://opendatakit.github.io/xforms-spec/#creation-removal-of-repeats) in the ODK XForms spec.

CC @nribeka @ukanga @MartijnR 