### PR TITLE
Remove "string" (alias of "text") from examples

### DIFF
--- a/_sections/home-english.md
+++ b/_sections/home-english.md
@@ -948,7 +948,7 @@ In your **survey** tab, group together the questions you would like to appear on
 | begin group | group1   |                      | field-list |
 | text        | name     | Respondent's name    |            |
 | integer     | age      | Respondent's age     |            |
-| string      | address  | Respondent's address |            |
+| text        | address  | Respondent's address |            |
 | end group   |          |                      |            |
 | =========   | ======== | ======               | ====       |
 | survey      |          |                      |            |
@@ -976,7 +976,7 @@ In your **survey** tab, group together the questions you would like to appear in
 | begin group | group1   |                      |            |
 | text        | name     | Respondent's name    | w3         |
 | integer     | age      | Respondent's age     | w1         |
-| string      | address  | Respondent's address | w4         |
+| text        | address  | Respondent's address | w4         |
 | end group   |          |                      |            |
 | =========   | ======== | ======               | ====       |
 | survey      |          |                      |            |


### PR DESCRIPTION
Question type `string` is an alias for type `text`. I've found it's quite confusing having it used in these examples where it's 2 lines below examples with `text`, which is documented above.

It's been in the doc since the initial commit of `xlsform.md` - [76b3d252](https://github.com/XLSForm/xlsform.github.io/blame/76b3d252473da84d66e0c35c3c3b1a761c46b22a/_includes/xlsform.md#L591).

pyxform compiles the two types the same

* [question_type_dictionary.py#L59](https://github.com/XLSForm/pyxform/blob/5c26ba3ed82a59c6b9bdbcbec534d6077a3767a0/pyxform/question_type_dictionary.py#L59)
* [question_type_dictionary.py#L71](https://github.com/XLSForm/pyxform/blob/5c26ba3ed82a59c6b9bdbcbec534d6077a3767a0/pyxform/question_type_dictionary.py#L71)