### PR TITLE
renamed "Home" to "XLSForm Docs"

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -1,8 +1,8 @@
---- 
-layout: home 
-lang: en 
+---
+layout: home
+lang: en
 ref: home
-title: Home
+title: XLSForm Docs
 ---
 
 {% include content.html %}


### PR DESCRIPTION
A minor change, but sets the `page.title` variable to "XLSForm Docs" so that the tab is no longer labeled "Home"

:neutral_face: 
![image](https://user-images.githubusercontent.com/97589/82377654-013afd80-99f2-11ea-889b-d3ecf1f62751.png)

:sunglasses: 
![image](https://user-images.githubusercontent.com/97589/82377852-48c18980-99f2-11ea-9294-04aeea58ae37.png)

